### PR TITLE
Load Open Sans font from Google APIs

### DIFF
--- a/idbase/templates/idbase/base.html
+++ b/idbase/templates/idbase/base.html
@@ -19,6 +19,7 @@
             <!-- bootstrap & font awesome -->
             <link rel="stylesheet" href="{% static "vendor/bootstrap/3.3.6/css/bootstrap.min.css" %}">
             <link rel="stylesheet" href="{% static "vendor/font-awesome/4.5.0/css/font-awesome.min.css" %}">
+            <link rel="stylesheet" id="google-font-open-css" href="https://fonts.googleapis.com/css?family=Open+Sans" type="text/css" media="all">
             {% compress css %}
                 {% block css %}
                     <link rel="stylesheet" href="{% static "idbase/css/main.css" %}">


### PR DESCRIPTION
Jeff thinks it's best to load fonts from canonical sources when possible so he'd rather use Google's font API instead of hosting a static font locally. This change will load the Open Sans font so that it will actually be used.
